### PR TITLE
Update 0x3E

### DIFF
--- a/src/data/1.14d/gs2client.json
+++ b/src/data/1.14d/gs2client.json
@@ -456,11 +456,12 @@
 	"D2GS_UPDATEITEMSTATS" : {
 		"PacketId" : "0x3E",
 		"Description" : "",
-		"Size" : -1,
+		"Size" : 34,
 		"Structure" : [ 
 			{ "BYTE" : "PacketId" }, 
 			{ "BYTE" : "nFullPacketSize" },
 			{ "BYTE" : "StatBitStream[nFullPacketSize - 2]" }
+			{ "BYTE" : "Padding[34 - nFullPacketSize]" }
 		]
 	},
 	"D2GS_USESTACKABLEITEM" : {

--- a/src/data/1.14d/gs2client.json
+++ b/src/data/1.14d/gs2client.json
@@ -460,7 +460,7 @@
 		"Structure" : [ 
 			{ "BYTE" : "PacketId" }, 
 			{ "BYTE" : "nFullPacketSize" },
-			{ "BYTE" : "StatBitStream[nFullPacketSize - 2]" }
+			{ "BYTE" : "StatBitStream[nFullPacketSize - 2]" },
 			{ "BYTE" : "Padding[34 - nFullPacketSize]" }
 		]
 	},


### PR DESCRIPTION
Seems to be incorrect:

```
void __fastcall ITEMS_UpdateClientStats(
        D2ClientStrc *pClient,
        D2UnitStrc *pItem,
        int32_t nPacketType,
        int32_t nStatID,
        int32_t nStatValue,
        int nParam)
{
  uint32_t dwUnitId; // edx
  D2BitBufferStrc a1; // [esp+8h] [ebp-3Ch] BYREF
  char Src[34]; // [esp+1Ch] [ebp-28h] BYREF

  *(_DWORD *)Src = 0x3E;
  memset(&Src[4], 0, 30);
  BITMANIP_Initialize(&a1, (int)&Src[2], 32);
  if ( pItem )
    dwUnitId = pItem->dwUnitId;
  else
    dwUnitId = -1;
  sub_53B0E0(&a1, dwUnitId);
  BITMANIP_Write(&a1, (_BYTE)nPacketType != 0, 1);
  BITMANIP_Write(&a1, nStatID, 9);
  sub_53B0E0(&a1, nStatValue);
  if ( (unsigned __int16)nParam >= 0x100u )
  {
    BITMANIP_Write(&a1, 1, 1);
    BITMANIP_Write(&a1, (unsigned __int16)nParam, 16);
  }
  else
  {
    BITMANIP_Write(&a1, 0, 1);
    BITMANIP_Write(&a1, (unsigned __int16)nParam, 8);
  }
  Src[1] = BITMANIP_GetSize(&a1) + 2;
  D2GAME_PACKETS_SendPacket_6FC3C710(pClient, Src, 34u);
}
```